### PR TITLE
add modulus cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ qa_deployer.deploy({
 
 Deploys the current package to [Modulus](https://modulus.io/).
 
-*Requirements*
-
- - The [Modulus CLI](https://github.com/onmodulus/modulus-cli) needs to be installed first.
-
 *Usage*
 
  - `auth` - An object with the Modulus account's `username` and `password`.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "async": "~0.8.0",
     "minimist": "~0.0.9",
+    "modulus": "^3.0.5",
     "request": "~2.33.0",
     "s3-site": "SparkartGroupInc/s3-site#remove-extensions-option"
   },

--- a/src/utils/modulus-cli.js
+++ b/src/utils/modulus-cli.js
@@ -1,4 +1,5 @@
 var spawn = require('child_process').spawn;
+var modulus = require.resolve('modulus/bin/modulus');
 
 exports.login = function(options, callback) {
   exports.command(['login', '--username', options.username, '--password', options.password], callback);
@@ -14,7 +15,7 @@ exports.deploy = function(options, callback) {
 };
 
 exports.command = function(args, callback) {
-  var child_process = spawn('modulus', args);
+  var child_process = spawn(modulus, args);
 
   child_process.stdout.pipe(process.stdout);
   child_process.stderr.pipe(process.stderr);


### PR DESCRIPTION
Add modulus CLI to dependencies so it doesn't have to be manually installed. This can make automatically deploying sites from Circle a little bit easier. https://github.com/SparkartGroupInc/bloodwater.org/pull/34
