### PR TITLE
Default deployer target name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+ - Default deployer target name
+
 ## 2.0.1 (Jan 16, 2015)
 
  - Install modulus-cli automatically [[1602923](https://github.com/SparkartGroupInc/qa-deployer/commit/16029235146e21a86cc2933ea1e0863bf412e627)]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Deploys the current package to [Modulus](https://modulus.io/).
 *Usage*
 
  - `auth` - An object with the Modulus account's `username` and `password`.
- - `project` - The Modulus project where to upload the package. If the project is missing, it will be automatically created.
+ - `project` - The Modulus project where to upload the package. If the project is missing, it will be automatically created. Optional, defaults to the current directory name.
  - `include_modules` - Whether to upload the `node_modules` folder. Optional, defaults to `false`.
 
 ### s3-static-website ###
@@ -45,7 +45,7 @@ Deploys the current directory to [Amazon S3](http://aws.amazon.com/s3/) as a [st
 *Usage*
 
  - `s3_options` - An object used to configure the connection to S3. See the `AWS.S3` [documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property).
- - `bucket_name` - The S3 bucket where to upload the files. If the bucket is missing, it will be automatically created and configured to host the static website.
+ - `bucket_name` - The S3 bucket where to upload the files. If the bucket is missing, it will be automatically created and configured to host the static website. Optional, defaults to the current directory name.
  - `region` - The AWS region where the site will be hosted. Optional, defaults to `us-east-1`.
  - `removeExtensions` - List of extensions to remove from uploaded files, for example `['.html', '.htm']`. Optional.
  - `indexDocument` - Default index document when a folder is requested from S3. Optional, defaults to `index.html`.
@@ -81,10 +81,12 @@ POSTs the deployed URL to a webhook URL, as JSON.
 
 Called by [CircleCI](https://circleci.com/), it automatically deploys a branch when a commit is made.
 
-The following deployers are supported:
+The following deployers are supported, with some usage changes:
 
- - `modulus` - The GitHub branch name is used as the Modulus project name.
- - `s3-static-website` - The GitHub organization, repository and branch names are used as the S3 bucket name.
+ - [modulus](#modulus)
+  - `project` - Defaults to the GitHub branch, unless it is `master`.
+ - [s3-static-website](#s3-static-website)
+  - `bucket_name` - Defaults to the GitHub organization, repository and branch (`[organization]-[repository]-[branch]`), unless the branch is `master`.
 
 Notifiers can be enabled by adding an options file. This JSON formatted file can contain deployer and notifier options, similar to the module usage above. For example:
 
@@ -153,7 +155,7 @@ deployment:
 
 ### circleci-deploy-github-pull-request ###
 
-Similar to the `circleci-deploy` script, but will only deploy when an open GitHub pull request exists for the current branch. If not, the branch will not be deployed, and will be withdrawn from the deployer service instead.
+Similar to the [circleci-deploy](#circleci-deploy) script, but will only deploy when an open GitHub pull request exists for the current branch. If not, the branch will not be deployed, and will be withdrawn from the deployer service instead.
 
 Note: CircleCI will only trigger new builds when a commit is made to an existing pull request. To deploy a branch when a pull request is created (without pushing an extra commit), the [CircleCI API](https://circleci.com/docs/api#new-build) needs to be called. On way to automatically do this is to create a [PullRequestEvent Webhook](https://developer.github.com/v3/activity/events/types/#pullrequestevent) in the GitHub project's settings. This Webhook will POST to a relay service, such as [Zapier](http://www.zapier.com), which will in turn POST to the appropriate CircleCI API URL.
 

--- a/src/deployers/modulus.js
+++ b/src/deployers/modulus.js
@@ -1,8 +1,11 @@
-var async = require('async');
+var async       = require('async');
 var modulus_api = require('../utils/modulus-api.js');
 var modulus_cli = require('../utils/modulus-cli.js');
+var utils       = require('../utils/utils.js');
 
 exports.init = function(options) {
+  options.project || (options.project = utils.cwdName());
+
   var redeploy;
   var review_url;
 

--- a/src/deployers/s3-static-website.js
+++ b/src/deployers/s3-static-website.js
@@ -1,8 +1,10 @@
 var async  = require('async');
 var Bucket = require('s3-site/lib/bucket').Bucket;
+var utils  = require('../utils/utils.js');
 
 exports.init = function(options) {
-  options.region || (options.region = 'us-east-1');
+  options.bucket_name || (options.bucket_name = utils.cwdName());
+  options.region      || (options.region = 'us-east-1');
 
   var bucket = new Bucket(
     {

--- a/src/utils/circleci.js
+++ b/src/utils/circleci.js
@@ -12,13 +12,13 @@ module.exports.getGitHubOptions = function(options) {
 module.exports.getDeployerOptions = function(options) {
   switch (options.service) {
   case 'modulus':
-    options.project || (options.project = getEnv('CIRCLE_BRANCH'));
+    options.project || (options.project = getModulusProject());
     options.auth    || (options.auth = {});
     options.auth.username || (options.auth.username = getEnv('MODULUS_USERNAME'));
     options.auth.password || (options.auth.password = getEnv('MODULUS_PASSWORD'));
     break;
   case 's3-static-website':
-    options.bucket_name || (options.bucket_name = getBucketName([getEnv('CIRCLE_PROJECT_USERNAME'), getEnv('CIRCLE_PROJECT_REPONAME'), getEnv('CIRCLE_BRANCH')]));
+    options.bucket_name || (options.bucket_name = getS3BucketName());
     options.s3_options  || (options.s3_options = {});
     options.s3_options.accessKeyId     || (options.s3_options.accessKeyId = getEnv('AWS_ACCESS_KEY_ID'));
     options.s3_options.secretAccessKey || (options.s3_options.secretAccessKey = getEnv('AWS_SECRET_ACCESS_KEY'));
@@ -76,6 +76,17 @@ var getEnv = function(name) {
   }
 };
 
-var getBucketName = function(parts) {
+var getModulusProject = function() {
+  var branch = getEnv('CIRCLE_BRANCH');
+  if (branch == 'master') return null;
+
+  return branch;
+};
+
+var getS3BucketName = function() {
+  var branch = getEnv('CIRCLE_BRANCH');
+  if (branch == 'master') return null;
+
+  var parts = [getEnv('CIRCLE_PROJECT_USERNAME'), getEnv('CIRCLE_PROJECT_REPONAME'), branch];
   return parts.join('-').toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/--+/g, '-').replace(/(^-|-$)/g, '').substring(0, 63).replace(/-$/, '');
 };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,0 +1,5 @@
+var path = require('path');
+
+module.exports.cwdName = function() {
+  return path.basename(process.cwd());
+};

--- a/test/deployers/modulus-test.js
+++ b/test/deployers/modulus-test.js
@@ -6,6 +6,7 @@ var sinon = require('sinon');
 
 var modulus_cli = require('../../src/utils/modulus-cli.js');
 var modulus = require('../../src/deployers/modulus.js');
+var utils = require('../../src/utils/utils.js');
 
 describe('deployers/modulus', function() {
   var options;
@@ -28,6 +29,16 @@ describe('deployers/modulus', function() {
     nock.cleanAll();
     nock.enableNetConnect();
     this.sinon.restore();
+  });
+
+  describe('.init()', function() {
+    it('initializes options.project', function(done) {
+      var mock_utils = this.sinon.mock(utils);
+      mock_utils.expects('cwdName').returns('some-project');
+
+      assert.equal(modulus.init({}).options.project, 'some-project');
+      done();
+    });
   });
 
   describe('.deploy()', function() {

--- a/test/deployers/s3-static-website-test.js
+++ b/test/deployers/s3-static-website-test.js
@@ -2,6 +2,7 @@ var assert = require('assert');
 var sinon = require('sinon');
 
 var s3_static_website = require('../../src/deployers/s3-static-website');
+var utils = require('../../src/utils/utils.js');
 
 describe('deployers/s3-static-website', function() {
   var options;
@@ -16,6 +17,21 @@ describe('deployers/s3-static-website', function() {
 
   afterEach(function() {
     this.sinon.restore();
+  });
+
+  describe('.init()', function() {
+    it('initializes options.bucket_name', function(done) {
+      var mock_utils = this.sinon.mock(utils);
+      mock_utils.expects('cwdName').returns('some-project');
+
+      assert.equal(s3_static_website.init({}).options.bucket_name, 'some-project');
+      done();
+    });
+
+    it('initializes options.region', function(done) {
+      assert.equal(s3_static_website.init({}).options.region, 'us-east-1');
+      done();
+    });
   });
 
   describe('.deploy()', function() {

--- a/test/utils/circleci-test.js
+++ b/test/utils/circleci-test.js
@@ -44,6 +44,16 @@ describe('utils/circleci', function() {
       done();
     });
 
+    it('modulus with master branch', function(done) {
+      process.env['CIRCLE_BRANCH']    = 'master';
+      process.env['MODULUS_USERNAME'] = 'me';
+      process.env['MODULUS_PASSWORD'] = 'mypassword';
+
+      var options = circleci.getDeployerOptions({service: 'modulus'});
+      assert.deepEqual(options, {service: 'modulus', project: null, auth: {username: 'me', password: 'mypassword'}});
+      done();
+    });
+
     it('s3-static-website', function(done) {
       process.env['CIRCLE_PROJECT_USERNAME'] = 'My Org';
       process.env['CIRCLE_PROJECT_REPONAME'] = '-- jfd. kjifds. mi92n%$$#@$';
@@ -53,6 +63,18 @@ describe('utils/circleci', function() {
 
       var options = circleci.getDeployerOptions({service: 's3-static-website'});
       assert.deepEqual(options, {service: 's3-static-website', bucket_name: 'my-org-jfd-kjifds-mi92n-jifjd-fd-0', s3_options: {accessKeyId: '12345', secretAccessKey: '54321'}});
+      done();
+    });
+
+    it('s3-static-website with master branch', function(done) {
+      process.env['CIRCLE_PROJECT_USERNAME'] = 'My Org';
+      process.env['CIRCLE_PROJECT_REPONAME'] = '-- jfd. kjifds. mi92n%$$#@$';
+      process.env['CIRCLE_BRANCH']           = 'master';
+      process.env['AWS_ACCESS_KEY_ID']       = '12345';
+      process.env['AWS_SECRET_ACCESS_KEY']   = '54321';
+
+      var options = circleci.getDeployerOptions({service: 's3-static-website'});
+      assert.deepEqual(options, {service: 's3-static-website', bucket_name: null, s3_options: {accessKeyId: '12345', secretAccessKey: '54321'}});
       done();
     });
 

--- a/test/utils/utils-test.js
+++ b/test/utils/utils-test.js
@@ -1,0 +1,20 @@
+var assert = require('assert');
+var path   = require('path');
+
+var utils = require('../../src/utils/utils');
+
+describe('utils/utils', function() {
+  describe('.cwdName()', function() {
+    var cwd = process.cwd();
+
+    afterEach(function() {
+      process.chdir(cwd);
+    });
+
+    it('returns the cwd name', function(done) {
+      process.chdir(__dirname);
+      assert.equal(utils.cwdName(), 'utils');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #9.

When a deployer is used without a target name (modulus' `project`, s3-static-website' `bucket_name`), a default name is used instead. If the current directory contains a `package.json` file, its `name` property is used. If not, or if `name` is missing, the current directory name is used.