### PR TITLE
Add option to pass environment vars to Modulus

### DIFF
--- a/src/deployers/modulus.js
+++ b/src/deployers/modulus.js
@@ -10,7 +10,7 @@ exports.init = function(options) {
   var review_url;
 
   var deploy = function(callback) {
-    async.series([authenticateUser, createProjectIfMissing, deployProject], function() {
+    async.series([authenticateUser, createProjectIfMissing, setEnvironmentVariables, deployProject], function() {
       callback(redeploy, review_url);
     });
   };
@@ -46,6 +46,14 @@ exports.init = function(options) {
         });
       }
     });
+  };
+
+  var setEnvironmentVariables = function(callback) {
+    if (!options.env) return callback();
+    console.log('Setting environment variables.');
+    async.each(Object.keys(options.env), function(key, next) {
+      modulus_cli.command(['env', 'set', key, options.env[key], '-p', options.project], next);
+    }, callback);
   };
 
   var deployProject = function(callback) {

--- a/test/deployers/modulus-test.js
+++ b/test/deployers/modulus-test.js
@@ -15,7 +15,10 @@ describe('deployers/modulus', function() {
   beforeEach(function() {
     options = {
       auth: {username: 'me', password: 'thePassword'},
-      project: 'theProject'
+      project: 'theProject',
+      env: {
+        TEST_VAR: 'testvalue'
+      }
     };
     nocks = [];
     nock.disableNetConnect();
@@ -53,6 +56,9 @@ describe('deployers/modulus', function() {
       nocks.push(nock('https://api.onmodulus.net').get('/user/123/projects?authToken=theToken').reply(200, []));
       nocks.push(nock('https://api.onmodulus.net').post('/project/create?authToken=theToken', {name: 'theProject', creator: 123}).reply(200, {name: 'theProject'}));
 
+      // setEnvironmentVariables
+      mock_modulus_cli.expects('command').withArgs(['env', 'set', 'TEST_VAR', 'testvalue', '-p', 'theProject']).yields();
+      
       // deployProject
       mock_modulus_cli.expects('command').withArgs(['deploy', '-p', 'theProject']).yields();
       nocks.push(nock('https://api.onmodulus.net').get('/user/123/projects?authToken=theToken').reply(200, [{name: 'theProject', domain: 'review/url'}]));
@@ -74,6 +80,9 @@ describe('deployers/modulus', function() {
       // createProjectIfMissing
       nocks.push(nock('https://api.onmodulus.net').get('/user/123/projects?authToken=theToken').reply(200, [{name: 'theProject'}]));
 
+      // setEnvironmentVariables
+      mock_modulus_cli.expects('command').withArgs(['env', 'set', 'TEST_VAR', 'testvalue', '-p', 'theProject']).yields();
+      
       // deployProject
       mock_modulus_cli.expects('command').withArgs(['deploy', '-p', 'theProject']).yields();
       nocks.push(nock('https://api.onmodulus.net').get('/user/123/projects?authToken=theToken').reply(200, [{name: 'theProject', domain: 'review/url'}]));


### PR DESCRIPTION
We can now use `options.env` in the config to pass environment variables to Modulus.

The primary use case for this at the moment is to set the NPM_TOKEN environment variable in Modulus based on it's value in the CI environment.
